### PR TITLE
Update nexus-staging-maven-plugin to version 1.6.13

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -115,7 +115,7 @@
             <plugin>
                 <groupId>org.sonatype.plugins</groupId>
                 <artifactId>nexus-staging-maven-plugin</artifactId>
-                <version>1.6.7</version>
+                <version>1.6.13</version>
                 <extensions>true</extensions>
                 <configuration>
                     <serverId>ossrh</serverId>


### PR DESCRIPTION
Updated the nexus-staging-maven-plugin version in the pom.xml from 1.6.7 to 1.6.13. This change ensures compatibility with the latest bug fixes and improvements provided by the plugin.